### PR TITLE
modif de la version de 3.0.0 à 3.0.1 de la dépendance jakarta.servlet…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.glassfish.web</groupId>
             <artifactId>jakarta.servlet.jsp.jstl</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet.jsp.jstl</groupId>


### PR DESCRIPTION
modif de la version de 3.0.0 à 3.0.1 de la dépendance jakarta.servlet.jsp.jstl afin de résoudre le problème de téléchargement de dépendance en local